### PR TITLE
Add excess custom defines logic

### DIFF
--- a/DevAccelerationSystem/Assets/DevAccelerationSystem/Editor/ProjectCompilationCheck/CompilationConfig.cs
+++ b/DevAccelerationSystem/Assets/DevAccelerationSystem/Editor/ProjectCompilationCheck/CompilationConfig.cs
@@ -22,6 +22,9 @@ namespace DevAccelerationSystem.ProjectCompilationCheck
         
         [Tooltip("Your custom scripting defines for the config.")]
         public string[] ExtraScriptingDefines;
+        
+        [Tooltip("Your custom scripting defines for the config which would be removed.")]
+        public string[] ExcessScriptingDefines;
 
         public override string ToString()
         {


### PR DESCRIPTION
Currently plugin supports behaviour which suggests that by default there is no excess custom define symbols, but with this improvement we can make more difficult configurations possible.